### PR TITLE
Migrate away from graphql to the Supabase client

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,6 +20,7 @@ const supabaseClient = createSupabaseClient(
 );
 console.log(supabaseClient);
 
+
 const urqlClient = createUrqlClient({
   url: process.env.REACT_APP_GRAPHQL_URL || `http://localhost:${process.env.PORT || 4000}/graphql`,
   fetchOptions: () => {


### PR DESCRIPTION
Running postgraphile is:
1. Annoying with supabase authentication
  - Have to create middleware
2. My use-case isn't actually too complicated to require graphql
3. The supabase client (postgrest) is able to perform table-joins and run remote procedures
4. Costly (to me) to run in a fargate container. EC2 is too much to manage with everything else.
5. Supabase client has subscriptions built-in with no extra coding
6. Writing postgres functions + supabase client does what I would be doing in graphql anyway
7. Graphql is slower
8. Supabase client makes graphql not really necessary for my use case and is creating more work
